### PR TITLE
refactor: Simplify field inheritance using get_type_hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ cython_debug/
 #.idea/
 
 .vscode/
+
+demo.py

--- a/src/cbridge/cbridge.py
+++ b/src/cbridge/cbridge.py
@@ -37,11 +37,12 @@ class CStructMeta(_BaseStructMeta):
         }
         fields = list(fields_map.items())
         if fields:
-            if sys.version_info < (3, 13):
-                cls._fields_ = fields
-            else:
-                # update fields
+            # update fields
+            if sys.version_info >= (3, 13):
                 cls._fields_[:] = fields
+            else:
+                cls._fields_ = fields
+
         cls = ds.dataclass(cls)
 
         @wraps(cls.__init__)

--- a/src/cbridge/cbridge.py
+++ b/src/cbridge/cbridge.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import ctypes
 import dataclasses as ds
 import sys
-import typing
 
 from functools import wraps
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import ClassVar
 from typing import TypeVar
 from typing import get_origin
+from typing import get_type_hints
 
 
 if sys.version_info >= (3, 12):
@@ -17,8 +18,6 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import dataclass_transform
 
-if TYPE_CHECKING:
-    from .types import CData
 
 _T = TypeVar("_T")
 
@@ -28,28 +27,16 @@ _BaseStructMeta: type = type(ctypes.Structure)
 @dataclass_transform()
 class CStructMeta(_BaseStructMeta):
     def __new__(meta_self, name: str, bases: tuple[type, ...], attrs: dict[str, Any]):  # type: ignore[misc]
-        annotations = attrs.get("__annotations__", {})
-
-        fields: list[tuple[str, type[CData]]] = []
-
-        def get_base_fields(cls):
-            fields = []
-            for base in reversed(cls.__mro__):
-                fields += getattr(base, "_fields_", [])
-            return fields
-
-        for base in bases:
-            fields += get_base_fields(base)
-
-        for f_name, field in annotations.items():
-            if get_origin(field) is typing.ClassVar:
-                continue
-            fields.append((f_name, field))
-
+        cls = super().__new__(meta_self, name, bases, attrs)
+        fields_map = {
+            f_name: f_type
+            for f_name, f_type in get_type_hints(cls).items()
+            if get_origin(f_type) is not ClassVar
+        }
+        fields = list(fields_map.items())
         if fields:
-            attrs["_fields_"] = tuple(fields)
-
-        cls = ds.dataclass(super().__new__(meta_self, name, bases, attrs))
+            cls._fields_ = fields
+        cls = ds.dataclass(cls)
 
         @wraps(cls.__init__)
         def wrapped_init(self, *args, **kwargs):
@@ -73,9 +60,8 @@ class CStructMeta(_BaseStructMeta):
                     else:
                         kwargs[field_name] = field_option
 
-            field_map = dict(fields)
             for arg_name, arg_value in kwargs.items():
-                field_type = field_map[arg_name]
+                field_type = fields_map[arg_name]
                 if issubclass(field_type, ctypes.Array):
                     kwargs[arg_name] = field_type(*arg_value)
 

--- a/src/cbridge/cbridge.py
+++ b/src/cbridge/cbridge.py
@@ -27,6 +27,7 @@ _BaseStructMeta: type = type(ctypes.Structure)
 @dataclass_transform()
 class CStructMeta(_BaseStructMeta):
     def __new__(meta_self, name: str, bases: tuple[type, ...], attrs: dict[str, Any]):  # type: ignore[misc]
+        attrs.setdefault("_fields_", [])
         cls = super().__new__(meta_self, name, bases, attrs)
         fields_map = {
             f_name: f_type
@@ -35,12 +36,8 @@ class CStructMeta(_BaseStructMeta):
         }
         fields = list(fields_map.items())
         if fields:
-            if sys.version_info < (3, 13):
-                cls._fields_ = fields
-            else:
-                # rebuild class with fields
-                attrs["_fields_"] = fields
-                cls = super().__new__(meta_self, name, bases, attrs)
+            # update fields
+            cls._fields_[:] = fields  # type: ignore[assignment]
         cls = ds.dataclass(cls)
 
         @wraps(cls.__init__)

--- a/src/cbridge/cbridge.py
+++ b/src/cbridge/cbridge.py
@@ -27,7 +27,8 @@ _BaseStructMeta: type = type(ctypes.Structure)
 @dataclass_transform()
 class CStructMeta(_BaseStructMeta):
     def __new__(meta_self, name: str, bases: tuple[type, ...], attrs: dict[str, Any]):  # type: ignore[misc]
-        attrs.setdefault("_fields_", [])
+        if sys.version_info >= (3, 13):
+            attrs["_fields_"] = []
         cls = super().__new__(meta_self, name, bases, attrs)
         fields_map = {
             f_name: f_type
@@ -36,8 +37,11 @@ class CStructMeta(_BaseStructMeta):
         }
         fields = list(fields_map.items())
         if fields:
-            # update fields
-            cls._fields_[:] = fields  # type: ignore[assignment]
+            if sys.version_info < (3, 13):
+                cls._fields_ = fields
+            else:
+                # update fields
+                cls._fields_[:] = fields
         cls = ds.dataclass(cls)
 
         @wraps(cls.__init__)

--- a/src/cbridge/cbridge.py
+++ b/src/cbridge/cbridge.py
@@ -35,7 +35,12 @@ class CStructMeta(_BaseStructMeta):
         }
         fields = list(fields_map.items())
         if fields:
-            cls._fields_ = fields
+            if sys.version_info < (3, 13):
+                cls._fields_ = fields
+            else:
+                # rebuild class with fields
+                attrs["_fields_"] = fields
+                cls = super().__new__(meta_self, name, bases, attrs)
         cls = ds.dataclass(cls)
 
         @wraps(cls.__init__)


### PR DESCRIPTION
The previous implementation of `CStructMeta` manually traversed the method resolution order (MRO) to collect fields from base classes. This approach was complex and brittle.

This commit refactors the metaclass to use `typing.get_type_hints()`. This simplifies the code significantly by leveraging the standard library to correctly resolve all fields, including those from parent classes. This change makes field discovery more robust and correctly handles forward-references in type annotations.