### PR TITLE
feat: Add pack support to CStruct

### DIFF
--- a/src/cbridge/cbridge.py
+++ b/src/cbridge/cbridge.py
@@ -26,9 +26,17 @@ _CStructType: type = type(ctypes.Structure)
 
 @dataclass_transform()
 class CStructType(_CStructType):
-    def __new__(meta_self, name: str, bases: tuple[type, ...], attrs: dict[str, Any]):  # type: ignore[misc]
+    def __new__(
+        meta_self,  # type: ignore[misc]
+        name: str,
+        bases: tuple[type, ...],
+        attrs: dict[str, Any],
+        pack: int = 0,
+        **extra,
+    ):
         if sys.version_info >= (3, 13):
             attrs["_fields_"] = []
+        attrs["_pack_"] = pack
         cls = super().__new__(meta_self, name, bases, attrs)
         fields_map = {
             f_name: f_type
@@ -86,7 +94,8 @@ field = ds.field
 if TYPE_CHECKING:
 
     @dataclass_transform(field_specifiers=(field,))
-    class CStruct(ctypes.Structure): ...
+    class CStruct(ctypes.Structure):
+        def __init_subclass__(cls, pack: int = 0) -> None: ...
 
 else:
 

--- a/tests/test_cstruct.py
+++ b/tests/test_cstruct.py
@@ -1,4 +1,5 @@
 import array
+import ctypes
 import sys
 
 from typing import ClassVar
@@ -145,3 +146,16 @@ def test_wchar_ptr_cstruct():
     data = WCharPtrData(a="hello")
     assert data.a is not None
     assert data.a == "hello"
+
+
+def test_pack_cstruct():
+    class DefaultPackData(CStruct):
+        a: types.char
+        b: types.int
+
+    class Pack1Data(CStruct, pack=1):
+        a: types.char
+        b: types.int
+
+    assert ctypes.sizeof(DefaultPackData) == 8
+    assert ctypes.sizeof(Pack1Data) == 5


### PR DESCRIPTION
This change introduces the ability to specify the 'pack' attribute for CStruct classes, which controls the memory alignment of the structure's fields.

This is achieved by passing a 'pack' argument to the CStruct class definition. The implementation forwards the 'pack' value to the underlying ctypes.Structure.

Unit tests have been added to verify that the 'pack' attribute correctly affects the size of the structure.