### PR TITLE
feat: Add cfunc decorator for C function binding

### DIFF
--- a/src/cbridge/__init__.py
+++ b/src/cbridge/__init__.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from .cbridge import CStruct
 from .cbridge import field
+from .cfunc import cfunc
 
 
 __version__ = "0.1.0b0"
 __authors__ = [
     "ZhengYu, Xu <zen-xu@outlook.com>",
 ]
-__all__ = ["CStruct", "field"]
+__all__ = ["CStruct", "cfunc", "field"]

--- a/src/cbridge/cfunc.py
+++ b/src/cbridge/cfunc.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import ctypes
+
+from ctypes.util import find_library
+from typing import Callable
+from typing import TypeVar
+from typing import get_type_hints
+
+
+_F = TypeVar("_F", bound=Callable)
+
+
+def cfunc(clib: str | ctypes.CDLL) -> Callable[[_F], _F]:
+    """
+    Decorator to bind a Python function signature to a C function from a shared library.
+
+    Args:
+        clib (str | ctypes.CDLL): The name of the C library (as a string) or a ctypes.CDLL instance.
+
+    Returns:
+        Callable[[_F], _F]: A decorator that replaces the Python function with the corresponding C function,
+        setting its argument and return types based on the Python type hints.
+
+    Examples:
+        >>> from cbridge import cfunc
+        >>> from cbridge import types
+        >>> from cbridge.types import pointer
+        >>> @cfunc("c")
+        ... def time(t: types.Pointer[types.ctime_t]) -> types.ctime_t: ...
+        >>> print(time(None))
+        >>> 1727433600
+    """
+    clib = ctypes.CDLL(find_library(clib)) if isinstance(clib, str) else clib
+
+    def wrapper(func: _F) -> _F:
+        hints = get_type_hints(func)
+        restype = hints.pop("return", None)
+        argtypes = list(hints.values())
+        cfunc = getattr(clib, func.__name__)
+        cfunc.restype = restype
+        cfunc.argtypes = tuple(argtypes)
+        return cfunc
+
+    return wrapper

--- a/tests/test_cfunc.py
+++ b/tests/test_cfunc.py
@@ -1,0 +1,10 @@
+from cbridge import cfunc
+from cbridge import types
+
+
+@cfunc("c")
+def strchr(s: types.char_ptr, c: types.char) -> types.char_ptr: ...
+
+
+def test_cfunc():
+    assert strchr(b"hello", b"o") == b"o"


### PR DESCRIPTION
This commit introduces the `cfunc` decorator, a new feature that simplifies binding Python functions to C functions in shared libraries.

The `cfunc` decorator uses Python type hints to automatically set the argument and return types (`argtypes` and `restype`) for the corresponding C function, reducing boilerplate and improving code readability.

Key changes include:
- Implementation of the `cfunc` decorator in `src/cbridge/cfunc.py`.
- A new test suite (`tests/test_cfunc.py`) to validate the decorator's functionality.
- Exporting `cfunc` in the main `cbridge` package.