### PR TITLE
fix: support forward declarations on Python 3.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,6 @@ print(Config(name=b"test"))  # Config(name=b'test', timeout=30, flags=[0, 1])
 
 ### Pointer Operations
 
-> [!WARNING]
-> Python 3.13 and above are currently not supported forward declarations
-
 ```python
 from cbridge import CStruct
 from cbridge import types

--- a/src/cbridge/cbridge.py
+++ b/src/cbridge/cbridge.py
@@ -36,10 +36,24 @@ class CStructType(_CStructType):
         pack: int = 0,
         **extra,
     ):
-        if sys.version_info >= (3, 13):
-            attrs["_fields_"] = []
-        attrs["_pack_"] = pack
-        cls = super().__new__(meta_self, name, bases, attrs)
+        if pack:
+            attrs["_pack_"] = pack
+            # Python 3.14+ only allows _pack_ with the MSVC-compatible layout
+            attrs["_layout_"] = "ms"
+        return super().__new__(meta_self, name, bases, attrs)
+
+    # Since Python 3.13, ctypes initializes structure storage info in tp_init
+    # instead of tp_new, so field resolution (which may create pointers to the
+    # class itself for forward declarations) must happen after super().__init__
+    def __init__(
+        cls,  # noqa: N805
+        name: str,
+        bases: tuple[type, ...],
+        attrs: dict[str, Any],
+        pack: int = 0,
+        **extra,
+    ):
+        super().__init__(name, bases, attrs)
         fields_map = {
             f_name: f_type
             for f_name, f_type in get_type_hints(
@@ -50,14 +64,11 @@ class CStructType(_CStructType):
         fields = list(fields_map.items())
         if fields:
             # update fields
-            if sys.version_info >= (3, 13):
-                cls._fields_[:] = fields
-            else:
-                cls._fields_ = fields
+            cls._fields_ = fields
 
-        cls = ds.dataclass(cls)
+        ds.dataclass(cls)
 
-        @wraps(cls.__init__)
+        @wraps(cls.__init__)  # type: ignore[misc]
         def wrapped_init(self, *args, **kwargs):
             args = list(args)
 
@@ -86,9 +97,7 @@ class CStructType(_CStructType):
 
             return ctypes.Structure.__init__(self, **kwargs)
 
-        cls.__init__ = wrapped_init
-
-        return cls
+        cls.__init__ = wrapped_init  # type: ignore[misc]
 
 
 field = ds.field

--- a/tests/test_cstruct.py
+++ b/tests/test_cstruct.py
@@ -1,11 +1,8 @@
 import array
 import ctypes
-import sys
 
 from typing import ClassVar
 from typing import Literal
-
-import pytest
 
 from cbridge import CStruct
 from cbridge import field
@@ -106,10 +103,6 @@ def test_class_var_cstruct():
     assert str(data) == f"{ClassVarData.__qualname__}(b=1)"
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 13),
-    reason="cell structure is not supported in python3.13 or higher",
-)
 def test_cell_cstruct():
     class CellData(CStruct):
         id: types.int


### PR DESCRIPTION
## Problem

On Python 3.13+, self-referential structures (forward declarations) fail:

```python
class Node(CStruct):
    data: types.int32
    next: "types.Pointer[Node]"
```

raises `TypeError: _type_ must have storage info`.

## Root cause

Since Python 3.13, ctypes initializes a structure's storage info (`StgInfo`) in the metaclass `tp_init` instead of `tp_new`. `CStructType` resolves type hints inside `__new__` — right after `super().__new__()` but before `tp_init` has run — so evaluating `"types.Pointer[Node]"` calls `ctypes.POINTER(Node)` on a class that has no storage info yet.

## Fix

- Move field resolution and `_fields_` assignment from the metaclass `__new__` into the metaclass `__init__`, after `super().__init__()` has initialized the storage info. Late `_fields_` assignment is the officially supported pattern for self-referential structures and works uniformly on all versions, so the previous 3.13-only empty-`_fields_` in-place-mutation workaround is removed.
- Only set `_pack_` when nonzero, and set `_layout_ = "ms"` alongside it, so packed structs keep working on Python 3.14+ (which rejects `_pack_` under the default gcc-sysv layout).
- Remove the 3.13 skip on `test_cell_cstruct` and the README warning.

## Testing

Full test suite (16 tests) passes on Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14; the README linked-list example now runs on 3.13/3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)